### PR TITLE
Bump Envoy to 1.32-latest

### DIFF
--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,5 +1,5 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
-FROM envoyproxy/envoy:v1.31-latest
+FROM envoyproxy/envoy:v1.32-latest
 
 WORKDIR /opt/envoy/
 

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -25,7 +25,7 @@ RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_
 COPY . .
 RUN ./mvnw clean package
 
-FROM envoyproxy/envoy:v1.31-latest
+FROM envoyproxy/envoy:v1.32-latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
Tested with 1.32.0 which works no worse than 1.30.6 or 1.31.2.