### PR TITLE
README: Fix docker-compose command with `down` first

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A template [.env.template](.env.template) can be copied to `.env` for your conve
 ## Build & Launch
 
 ```bash
-docker-compose up --build
+docker-compose down && docker-compose up --build
 ```
 
 This will build and launch the following components:


### PR DESCRIPTION
If not running `docker-compose down` before `up`, it can be possible that `up` fails. So add the missing command.