### PR TITLE
agent: Add span log collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+agent/logs/*

--- a/agent/com.instana.agent.main.sender.File.cfg
+++ b/agent/com.instana.agent.main.sender.File.cfg
@@ -1,0 +1,10 @@
+# Configuration of local logging. Changes will be hot-reloaded.
+# Activate logging of outgoing payloads to local disk by setting a non-empty
+# prefix. The log file will be written to data/log, and the file will have the
+# defined prefix followed by a timestamp.
+# Note: There is no automatic rotation of those files.
+prefix=spans
+
+# The file can be filtered to either "metrics" or "traces".
+# If empty or absent, there will be no filtering.
+type=traces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,11 @@ services:
     volumes:
       - /var/run:/var/run
       - /run:/run
-      - /dev:/dev:ro
-      - /sys:/sys:ro
-      - /var/log:/var/log:ro
       - ./agent/configuration.yaml:/opt/instana/agent/etc/instana/configuration.yaml:ro
+      # Include the File.cfg so spans are written to disk. We use them to verify which spans have been sent to the agent.
+      - ./agent/com.instana.agent.main.sender.File.cfg:/opt/instana/agent/etc/instana/com.instana.agent.main.sender.File.cfg:ro
+      # Mount the logs directly so we can directly access the span-*.log files to check the produced spans.
+      - ./agent/logs:/opt/instana/agent/data/log
     networks:
       envoymesh:
         aliases:
@@ -69,6 +70,11 @@ services:
       - INSTANA_AGENT_KEY=${agent_key}
       - INSTANA_DOWNLOAD_KEY=${download_key}
       - INSTANA_AGENT_ZONE=${agent_zone:-envoy-tracing-demo}
+    healthcheck:
+      test: ["CMD", "curl", "localhost:42699"]
+      interval: 8s
+      timeout: 10s
+      retries: 5
     expose:
       - "42699"
       - "4317"


### PR DESCRIPTION
Do it the same way as in the `nginx-tracing` repo.
Also add the agent TCP port 42699 health check.