### PR TITLE
Bump Envoy to 1.34.3

### DIFF
--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,7 +1,7 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
 #
 # Do not use "-latest" versions because those are not updated without always pull policy
-FROM envoyproxy/envoy:v1.34.1
+FROM envoyproxy/envoy:v1.34.3
 
 WORKDIR /opt/envoy/
 

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -27,7 +27,7 @@ RUN ./mvnw clean package
 
 #
 # Do not use "-latest" versions because those are not updated without always pull policy
-FROM envoyproxy/envoy:v1.34.1
+FROM envoyproxy/envoy:v1.34.3
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
Tested with Envoy versions 1.34.2 and 1.34.3. 