### PR TITLE
server-app: Remove libinstana dependency from envoy-otel-tracing

### DIFF
--- a/envoy/envoy-gateway.yaml
+++ b/envoy/envoy-gateway.yaml
@@ -1,5 +1,4 @@
 # Based on: https://github.com/envoyproxy/envoy/tree/main/examples/front-proxy
-# Modification by Instana: add tracing configuration for libinstana_sensor.so
 static_resources:
   listeners:
     - address:

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -9,19 +9,6 @@ RUN apt-get update \
 
 WORKDIR /opt/server-app/
 
-# download latest libinstana_sensor from artifactory
-ARG agent_key
-ARG download_key
-ENV ARTI_PATH='https://artifact-public.instana.io/artifactory/shared/com/instana/libinstana_sensor/' \
-    INSTANA_DOWNLOAD_KEY=${download_key} \
-    INSTANA_AGENT_KEY=${agent_key}
-
-RUN access_key=$([ ! -z "${INSTANA_DOWNLOAD_KEY}" ] && echo "${INSTANA_DOWNLOAD_KEY}" || echo "${INSTANA_AGENT_KEY}") \
-    && wget --user _ --password ${access_key} --output-document=./list.html ${ARTI_PATH} \
-    && sensor_version=$(grep -o "href=\"[0-9]\+\.[0-9]\+\.[0-9]\+/\"" ./list.html | tail -n1 | cut -d'"' -f2) \
-    && echo "Using sensor version ${sensor_version}" \
-    && wget --user _ --password ${access_key} --output-document=./libcxx-libinstana_sensor.so ${ARTI_PATH}${sensor_version}linux-amd64-libcxx-libinstana_sensor.so
-
 COPY . .
 RUN ./mvnw clean package
 
@@ -42,7 +29,6 @@ WORKDIR /opt/server-app/
 
 ARG jar_file=target/server-app-1.0.0.RELEASE.jar
 COPY --from=envoy-tracing-server-app-build /opt/server-app/${jar_file} ./app.jar
-COPY --from=envoy-tracing-server-app-build /opt/server-app/libcxx-libinstana_sensor.so ./
 
 COPY ./start-server-app.sh ./envoy-server-app.yaml ./
 ENTRYPOINT ["./start-server-app.sh"]

--- a/server-app/envoy-server-app.yaml
+++ b/server-app/envoy-server-app.yaml
@@ -1,5 +1,4 @@
 # Based on: https://github.com/envoyproxy/envoy/tree/main/examples/front-proxy
-# Modification by Instana: add tracing configuration for libinstana_sensor.so
 static_resources:
   listeners:
     - address:


### PR DESCRIPTION
## Reference

- [Jira Ticket](https://jsw.ibm.com/browse/INSTA-75499)

## why

The libinstana_sensor library was downloaded and copied into the container but is not used. Tracing is handled by Envoy's OpenTelemetry integration.

## what

The download and deployment steps for libinstana_sensor have been removed from the Dockerfile, and the related comments have been removed.

## Test

<img width="1676" height="942" alt="Envoy" src="https://github.com/user-attachments/assets/cea291bf-e54f-4e5f-97d5-e44c8181ca88" />


