### PR TITLE
Bump Envoy to 1.37.1

### DIFF
--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -1,7 +1,7 @@
 # Original from envoyproject/envoy:examples/front-proxy/Dockerfile-frontenvoy
 #
 # Do not use "-latest" versions because those are not updated without always pull policy
-FROM envoyproxy/envoy:v1.37.0
+FROM envoyproxy/envoy:v1.37.1
 
 WORKDIR /opt/envoy/
 

--- a/server-app/Dockerfile
+++ b/server-app/Dockerfile
@@ -14,7 +14,7 @@ RUN ./mvnw clean package
 
 #
 # Do not use "-latest" versions because those are not updated without always pull policy
-FROM envoyproxy/envoy:v1.37.0
+FROM envoyproxy/envoy:v1.37.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
Bump envoy version to 1.37.1

Test:
<img width="1664" height="907" alt="envoy1 37 1" src="https://github.com/user-attachments/assets/4870a9bd-b20c-49e8-8c0b-d3210067deeb" />
