### PR TITLE
agent, docker-compose: Disable Java tracing span batching

### DIFF
--- a/agent/configuration.yaml
+++ b/agent/configuration.yaml
@@ -123,8 +123,9 @@
 #          type: 'absolute' # absolute will report the value as-is
 
 # Java Tracing
-#com.instana.plugin.javatrace:
-#  instrumentation:
+com.instana.plugin.javatrace:
+  instrumentation:
+    spanBatchingEnabled: false
 #    # Lightweight Bytecode Instrumentation, enabled by default
 #    # Disabling currently requires an agent restart
 #    enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     networks:
       - envoymesh
     environment:
+      - INSTANA_SPANBATCHING_ENABLED=false
       - INSTANA_DEV=1
       - target_url=http://envoy-gateway:8000/envoy-demo
 


### PR DESCRIPTION
The Java tracer uses span batching by default. This can cause several issues with delayed spans, faulty span correlation and other things. The Instana QA team has requested that we disable the Java tracer span batching because of this.

So disable span batching via environment variable
`INSTANA_SPANBATCHING_ENABLED=false`.

Also disable span batching via agent config:
```
  com.instana.plugin.javatrace:
    instrumentation:
      spanBatchingEnabled: false
```

The issue here is that Instana UI still shows `BATCH` and the span names in the `agent/logs/spans-*.log` are also still `spring-batch`.

To verify that this is really set, the following Instana agent environment variables have to be set:
```
    environment:
      - INSTANA_LOG_LEVEL=DEBUG
      - INSTANA_ROOT_LOGGER_LOG_LEVEL=DEBUG
      - INSTANA_ROOT_LOGGER_CONSOLE_APPENDER_LOG_LEVEL=DEBUG
```

Then, value "spanBatchingEnabled=false" can be found in an agent debug message "Starting agent com.instana.agent.javatrace.AgentMain args:".

References:
https://www.ibm.com/docs/en/instana-observability?topic=machine-configuring-java-sensor#ariaid-title29 https://www.ibm.com/docs/en/instana-observability?topic=references-environment-variables